### PR TITLE
Enable Verified Tasks Edit Flag

### DIFF
--- a/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
+++ b/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
@@ -158,6 +158,12 @@ export function TaskTemplateOverview({
 
   const params = useParams();
   const history = useHistory();
+
+  const invalidateQueries = () => {
+    queryCache.invalidateQueries(serviceUrl.getTaskTemplates());
+    queryCache.invalidateQueries(serviceUrl.getFeatureFlags());
+  };
+
   const [uploadTaskTemplateMutation, { isLoading }] = useMutation(
     (args) => {
       const { promise, cancel } = resolver.putCreateTaskTemplate(args);
@@ -165,17 +171,17 @@ export function TaskTemplateOverview({
       return promise;
     },
     {
-      onSuccess: () => queryCache.invalidateQueries([serviceUrl.getTaskTemplates()]),
+      onSuccess: invalidateQueries,
     }
   );
   const [archiveTaskTemplateMutation, { isLoading: archiveIsLoading }] = useMutation(
     resolver.deleteArchiveTaskTemplate,
     {
-      onSuccess: () => queryCache.invalidateQueries([serviceUrl.getTaskTemplates()]),
+      onSuccess: invalidateQueries,
     }
   );
   const [restoreTaskTemplateMutation, { isLoading: restoreIsLoading }] = useMutation(resolver.putRestoreTaskTemplate, {
-    onSuccess: () => queryCache.invalidateQueries([serviceUrl.getTaskTemplates()]),
+    onSuccess: invalidateQueries,
   });
 
   let selectedTaskTemplate = taskTemplates.find((taskTemplate) => taskTemplate.id === params.id) ?? {};

--- a/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
+++ b/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
@@ -1,6 +1,5 @@
 //@ts-nocheck
 import React from "react";
-import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { Formik } from "formik";
 import axios from "axios";
@@ -29,7 +28,7 @@ import { taskIcons } from "Utils/taskIcons";
 import { resolver, serviceUrl } from "Config/servicesConfig";
 import { appLink, AppPath } from "Config/appConfig";
 import { Draggable16, TrashCan16, Archive16, Bee16, Recommend16, Identification16 } from "@carbon/icons-react";
-import { DataDrivenInput } from "Types";
+import { DataDrivenInput, TaskModel } from "Types";
 import styles from "./taskTemplateOverview.module.scss";
 
 const ArchiveText: React.FC = () => (
@@ -147,13 +146,17 @@ const Field: React.FC<FieldProps> = ({
   );
 };
 
-TaskTemplateOverview.propTypes = {
-  taskTemplates: PropTypes.array.isRequired,
-  updateTemplateInState: PropTypes.func.isRequired,
-  editVerifiedTasksEnabled: PropTypes.bool.isRequired,
+type TaskTemplateOverviewProps = {
+  taskTemplates: any[];
+  updateTemplateInState: (args: TaskModel) => void;
+  editVerifiedTasksEnabled: any;
 };
 
-export function TaskTemplateOverview({ taskTemplates, updateTemplateInState, editVerifiedTasksEnabled }) {
+export function TaskTemplateOverview({
+  taskTemplates,
+  updateTemplateInState,
+  editVerifiedTasksEnabled,
+}: TaskTemplateOverviewProps) {
   const cancelRequestRef = React.useRef();
 
   const params = useParams();

--- a/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
+++ b/src/Features/TaskTemplates/TaskTemplateOverview/TaskTemplateOverview.tsx
@@ -41,9 +41,6 @@ const ArchiveText: React.FC = () => (
       here. The task will remain functional in any existing Workflows to avoid breakage.
     </p>
     <p className={styles.confirmModalText}>You can restore an archived task later, if needed.</p>
-    <p className={styles.confirmModalText}>
-      If you need to permanently delete a task, contact a Boomerang Admin to help (bmrgjoe@bmrg.com).
-    </p>
   </>
 );
 

--- a/src/Features/TaskTemplates/TaskTemplates.tsx
+++ b/src/Features/TaskTemplates/TaskTemplates.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import { useFeature } from "flagged";
 import { useQuery } from "Hooks";
 import { queryCache } from "react-query";
 import { Route, Switch, useRouteMatch, Redirect } from "react-router-dom";
@@ -11,20 +12,22 @@ import Sidenav from "./Sidenav";
 import TaskTemplateOverview from "./TaskTemplateOverview";
 import orderBy from "lodash/orderBy";
 import { TaskModel } from "Types";
-import { AppPath, appLink } from "Config/appConfig";
+import { AppPath, appLink, FeatureFlag } from "Config/appConfig";
 import { serviceUrl } from "Config/servicesConfig";
-import { stringToBooleanHelper } from "Utils/stringHelper";
+// import { stringToBooleanHelper } from "Utils/stringHelper";
 import styles from "./taskTemplates.module.scss";
 
-const settingsWorkersName = "Workers";
+// const settingsWorkersName = "Workers";
 
 const TaskTemplatesContainer: React.FC = () => {
   const match = useRouteMatch();
   const getTaskTemplatesUrl = serviceUrl.getTaskTemplates();
   const platformSettingsUrl = serviceUrl.resourceSettings();
+  const editVerifiedTasksEnabled = useFeature(FeatureFlag.EditVerifiedTasksEnabled);
   const { data: taskTemplatesData, error: taskTemplatesDataError, isLoading } = useQuery(getTaskTemplatesUrl);
 
-  const { data: settingsData, error: settingsError, isLoading: settingsIsLoading } = useQuery(platformSettingsUrl);
+  // const { data: settingsData, error: settingsError, isLoading: settingsIsLoading } = useQuery(platformSettingsUrl);
+  const { error: settingsError, isLoading: settingsIsLoading } = useQuery(platformSettingsUrl);
 
   const addTemplateInState = (newTemplate: TaskModel) => {
     const updatedTemplatesData = [...taskTemplatesData];
@@ -53,11 +56,12 @@ const TaskTemplatesContainer: React.FC = () => {
     );
   }
 
-  const editVerifiedTasksEnabled = stringToBooleanHelper(
-    settingsData
-      .find((arr: any) => arr.name === settingsWorkersName)
-      ?.config?.find((setting: { key: string }) => setting.key === "enable.tasks").value ?? false
-  );
+  // const editVerifiedTasksEnabled = stringToBooleanHelper(
+  //   settingsData
+  //     .find((arr: any) => arr.name === settingsWorkersName)
+  //     ?.config?.find((setting: { key: string }) => setting.key === "enable.tasks").value ?? false
+  // );
+
   return (
     <div className={styles.container}>
       <Helmet>

--- a/src/Features/TaskTemplates/TaskTemplates.tsx
+++ b/src/Features/TaskTemplates/TaskTemplates.tsx
@@ -14,20 +14,13 @@ import orderBy from "lodash/orderBy";
 import { TaskModel } from "Types";
 import { AppPath, appLink, FeatureFlag } from "Config/appConfig";
 import { serviceUrl } from "Config/servicesConfig";
-// import { stringToBooleanHelper } from "Utils/stringHelper";
 import styles from "./taskTemplates.module.scss";
-
-// const settingsWorkersName = "Workers";
 
 const TaskTemplatesContainer: React.FC = () => {
   const match = useRouteMatch();
   const getTaskTemplatesUrl = serviceUrl.getTaskTemplates();
-  const platformSettingsUrl = serviceUrl.resourceSettings();
   const editVerifiedTasksEnabled = useFeature(FeatureFlag.EditVerifiedTasksEnabled);
   const { data: taskTemplatesData, error: taskTemplatesDataError, isLoading } = useQuery(getTaskTemplatesUrl);
-
-  // const { data: settingsData, error: settingsError, isLoading: settingsIsLoading } = useQuery(platformSettingsUrl);
-  const { error: settingsError, isLoading: settingsIsLoading } = useQuery(platformSettingsUrl);
 
   const addTemplateInState = (newTemplate: TaskModel) => {
     const updatedTemplatesData = [...taskTemplatesData];
@@ -44,23 +37,17 @@ const TaskTemplatesContainer: React.FC = () => {
     }
   };
 
-  if (isLoading || settingsIsLoading) {
+  if (isLoading) {
     return <Loading />;
   }
 
-  if (taskTemplatesDataError || settingsError) {
+  if (taskTemplatesDataError) {
     return (
       <div className={styles.container}>
         <ErrorDragon />
       </div>
     );
   }
-
-  // const editVerifiedTasksEnabled = stringToBooleanHelper(
-  //   settingsData
-  //     .find((arr: any) => arr.name === settingsWorkersName)
-  //     ?.config?.find((setting: { key: string }) => setting.key === "enable.tasks").value ?? false
-  // );
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Context

- Some verified task can't be editted despite feature flag "enable.verified.tasks.edit" being `true`.
- Also updated the message for Archive Task modal (https://app.zenhub.com/workspaces/boomerang-flow-5f9600754a5aa9001521ccc1/issues/boomerang-io/roadmap/69).

Build Number: ~3.0.74~ 3.0.75

## Checklist:

- [ ] Verified in an integrated environment
- [ ] Unit and integration tests passing
- [ ] Semantic HTML with accessibility support
- [ ] No linting, test console, or browser console errors (best effort)
- [ ] JSDoc comment blocks for complex code


## PR Review Guidance
Check "Features/TaskTemplates"
