### PR TITLE
fix: currentAction optional chaining

### DIFF
--- a/src/Features/Actions/ActionsTable/ActionsTable.tsx
+++ b/src/Features/Actions/ActionsTable/ActionsTable.tsx
@@ -352,7 +352,7 @@ function ActionsTable(props: ActionsTableProps) {
                           const currentAction: Action = records.find((action: Action) => action.id === row.id);
                           const isAlreadyApproved =
                             (user?.id && currentAction?.actioners?.map((user) => user.approverId).includes(user.id)) ||
-                            currentAction.status !== ApprovalStatus.Submitted;
+                            currentAction?.status !== ApprovalStatus.Submitted;
                           return isManual ? (
                             <TableRow
                               key={row.id}

--- a/src/Features/Actions/ActionsTable/ApproveRejectActions/ApproveRejectActions.tsx
+++ b/src/Features/Actions/ActionsTable/ApproveRejectActions/ApproveRejectActions.tsx
@@ -372,7 +372,7 @@ function SingleActionSection({ formikBag, action, isAlreadyApproved, user }: Sin
           </p>
         </div>
       )}
-      {actioners.length && (
+      {Array.isArray(actioners) && actioners.length && (
         <div className={styles.approvers}>
           <p className={styles.singleLabel}>Approvers who submitted</p>
           <StructuredListWrapper>


### PR DESCRIPTION
## Context

Related Issues(s): https://app.zenhub.com/workspaces/boomerang-flow-5f9600754a5aa9001521ccc1/issues/boomerang-io/roadmap/234

Build Number: 3.4.2

## PR Review Guidance
Added optional chaining to avoid error when not finding currentAction.
