### PR TITLE
feat: support unicode team name and add length constraint

### DIFF
--- a/src/Features/Editor/Configure/CreateToken/CreateToken.tsx
+++ b/src/Features/Editor/Configure/CreateToken/CreateToken.tsx
@@ -121,7 +121,7 @@ const CreateTokenModalContent: React.FC<CreateTokenModalContentProps> = ({
       onSubmit={generateToken}
       validationSchema={Yup.object().shape({
         label: Yup.string()
-          .required("Enter a team name")
+          .required("Enter a token label")
           .min(4, "Token label must be at least four characters")
           .max(80, "Token label must be 80 characters or less")
           .matches(/^[a-zA-Z0-9 ]+$/, "Token label must only contain ASCII alphanumeric characters and spaces")

--- a/src/Features/TeamDetailed/Settings/UpdateTeamName/UpdateTeamName.tsx
+++ b/src/Features/TeamDetailed/Settings/UpdateTeamName/UpdateTeamName.tsx
@@ -57,7 +57,7 @@ const UpdateTeamName: React.FC<UpdateTeamNameProps> = ({ closeModal, team, teamN
       validationSchema={Yup.object().shape({
         name: Yup.string()
           .required("Enter a team name")
-          .matches(/^[a-zA-Z0-9 ]+$/, "Team name must only contains alphanumeric characters or spaces")
+          .max(100, "Enter team name that is at most 100 characters in length")
           .notOneOf(teamNameList, "Please try again, select a team name that is not already in use"),
       })}
     >

--- a/src/Features/Teams/AddTeamContent/AddTeamContent.tsx
+++ b/src/Features/Teams/AddTeamContent/AddTeamContent.tsx
@@ -74,8 +74,8 @@ export default function AddTeamContent({
       validationSchema={Yup.object().shape({
         name: Yup.string()
           .required("Enter a team name")
-          .matches(/^[a-zA-Z0-9 ]+$/, "Team name must only contains alphanumeric characters or spaces")
-          .notOneOf(teamNameList, "Please try again, select a team name that is not already in use"),
+          .max(100, "Enter team name that is at most 100 characters in length")
+          .notOneOf(teamNameList, "Please try again, enter a team name that is not already in use"),
       })}
     >
       {(formikProps) => {


### PR DESCRIPTION
## Context

Related Issues(s): 
Closes https://github.com/boomerang-io/roadmap/issues/275

Build Number: n/a

## Checklist:

- [ ] Verified in an integrated environment
- [ ] Unit and integration tests passing
- [ ] Semantic HTML with accessibility support
- [ ] No linting, test console, or browser console errors (best effort)
- [ ] JSDoc comment blocks for complex code


## PR Review Guidance

Can you create a team with a name / edit an existing team name to have any unicode character in it and not be longer than 100 characters

## Additional Info
